### PR TITLE
Remove unnecessary code.

### DIFF
--- a/keymap.rb
+++ b/keymap.rb
@@ -1,7 +1,3 @@
-while !$mutex
-  relinquish
-end
-
 kbd = Keyboard.new
 
 kbd.split = true


### PR DESCRIPTION
In the latest PRK Firmware version 0.9.8 (probably, 0.9.6 or higher), it freezes the while loop of the `relinquish` call. The code is unnecessary for the latest firmware, therefore this pull request removes the code.