### PR TITLE
Fix the RGB mode name issue.

### DIFF
--- a/keymap.rb
+++ b/keymap.rb
@@ -50,7 +50,7 @@ rgb = RGB.new(
   0,
   false
 )
-rgb.effect = :breathing
+rgb.effect = :rainbow_mood
 kbd.append rgb
 
 kbd.start!


### PR DESCRIPTION
The current RGB mode name `breathing` has already been old.