### PR TITLE
Support the "Sounder" feature and play the sound on startup.

### DIFF
--- a/keymap.rb
+++ b/keymap.rb
@@ -1,4 +1,5 @@
 require "via"
+require "sounder"
 
 kbd = Keyboard.new
 
@@ -57,5 +58,13 @@ rgb = RGB.new(
 )
 rgb.effect = :rainbow_mood
 kbd.append rgb
+
+sounder = Sounder.new(8)
+
+kbd.on_start do
+  if kbd.anchor?
+    sounder.play "T200 L8 O7 c O6 c"
+  end
+end
 
 kbd.start!


### PR DESCRIPTION
Since the PRK Firmware version 0.9.18, the "Sounder" feature is available to play sounds. Lunakey Pico has a speaker, therefore I want to add a logic to play a sound at startup. 